### PR TITLE
Add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
   "repository": "https://github.com/julien-maurel/jQuery-Storage-API",
   "files": [
     "jquery.storageapi.js"
-  ]
+  ],
+  "main": "jquery.storageapi.js"
 }


### PR DESCRIPTION
This makes the module requirable `require('jquery-storage-api')`
